### PR TITLE
fix: escape command line

### DIFF
--- a/zsh-tab-title.plugin.zsh
+++ b/zsh-tab-title.plugin.zsh
@@ -73,7 +73,7 @@ function omz_termsupport_preexec {
 
   if [[ "$ZSH_TAB_TITLE_ENABLE_FULL_COMMAND" == true ]]; then
   	  # full command
-	  local CMD=${1}
+	  local CMD=${1:gs/%/%%}
   else
 	  # cmd name only, or if this is sudo or ssh, the next cmd
 	  local CMD=${1[(wr)^(*=*|sudo|ssh|mosh|rake|-*)]:gs/%/%%}

--- a/zsh-tab-title.plugin.zsh
+++ b/zsh-tab-title.plugin.zsh
@@ -2,7 +2,7 @@
 
 # Set terminal window and tab/icon title
 #
-# usage: title short_tab_title [long_window_title]
+# usage: title short_tab_title long_window_title
 #
 # See: http://www.faqs.org/docs/Linux-mini/Xterm-Title.html#ss3.1
 # Fully supports screen, hyper, iterm, and probably most modern xterm and rxvt
@@ -13,25 +13,24 @@ function title {
   
   [[ "$EMACS" == *term* ]] && return
 
-  # if $2 is unset use $1 as default
-  # if it is set and empty, leave it as is
-  : "${2=$1}"
+  tabTitle="\$1"
+  termTitle="\$2"
 
   if [[ "$TERM_PROGRAM" == "iTerm.app" ]]; then
-    print -Pn "\e]2;$2:q\a" # set window name
-    print -Pn "\e]1;$1:q\a" # set tab name
+    print -Pn "\e]2;$termTitle:q\a" # set window name
+    print -Pn "\e]1;$tabTitle:q\a" # set tab name
   elif [[ "$TERM_PROGRAM" == "Hyper" ]]; then
-    print -Pn "\e]1;$2:q\a" # set tab name
-    print -Pn "\e]2;$1:q\a" # set window name
+    print -Pn "\e]1;$termTitle:q\a" # set tab name
+    print -Pn "\e]2;$tabTitle:q\a" # set window name
   else
     case "$TERM" in
       cygwin|xterm*|putty*|rxvt*|ansi|${~ZSH_TAB_TITLE_ADDITIONAL_TERMS})
-        print -Pn "\e]2;$2:q\a" # set window name
-        print -Pn "\e]1;$1:q\a" # set tab name
+        print -Pn "\e]2;$termTitle:q\a" # set window name
+        print -Pn "\e]1;$tabTitle:q\a" # set tab name
       ;;
-      
+
       screen*|tmux*)
-        print -Pn "\ek$1:q\e\\" # set screen hardstatus
+        print -Pn "\ek$tabTitle:q\e\\" # set screen hardstatus
       ;;
     esac
   fi


### PR DESCRIPTION
The `ZSH_TAB_TITLE_ENABLE_FULL_COMMAND` feature was not escaping the command properly.

before:
```
# date +%s
27m1638406952
```

after:
```
# date +%s
1638407240
```