### PR TITLE
fix: Make deprecation log more actionable

### DIFF
--- a/zsh-tab-title.plugin.zsh
+++ b/zsh-tab-title.plugin.zsh
@@ -103,4 +103,4 @@ autoload -U add-zsh-hook
 add-zsh-hook precmd omz_termsupport_precmd
 add-zsh-hook preexec omz_termsupport_preexec
 
-echo "You are currently using an deprecated version of this plugin. Please uninstall the plugin and install the new version or you will start to have problems soon."
+echo "You are currently using a deprecated version of zsh-tab-title. The default branch has changed from master to main. Reinstall the plugin or follow the instructions in the README to upgrade."


### PR DESCRIPTION
Hello!

Thanks for your work on `zsh-tab-title`, much appreciated!
While booting up my terminal I noticed a deprecation log, but I didn't know where it came from! Only after using verbose logging for zsh (https://unix.stackexchange.com/questions/559075/does-zsh-have-some-kind-of-diagnostic-mode) I was able to figure out where this log came from.

To save the struggle for others I improved the log to make it clear where it came from and what one needs to do.