### PR TITLE
feat: Add command name overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,25 @@ ZSH_TAB_TITLE_SUFFIX='- $USER'
 
 This variable has no default value, so if nothing is informed, no suffix is added
 
+### COMMAND MAPPING
+
+You can map command names to custom display names using the `ZSH_TAB_TITLE_CMD_MAP` associative array:
+
+```sh
+typeset -gA ZSH_TAB_TITLE_CMD_MAP
+ZSH_TAB_TITLE_CMD_MAP=(
+  "node" " NodeJS"
+  "python3" " 🐍 Python"
+  "docker-compose" " ⛴️ Docker"
+  "nvim" " NeoVim"
+  "git" " Git"
+)
+```
+
+This must be declared **before** loading the plugin in your `.zshrc`. The mapping applies to the command name extracted by the plugin (after stripping sudo, ssh, etc.).
+
+**Example**: When running `node server.js`, the tab title will show `NodeJS` (or `NodeJS server.js` if `ZSH_TAB_TITLE_ENABLE_FULL_COMMAND=true`).
+
 ### ADDITIONAL TERMS
 
 By default the tab title is set for iTerm, Hyper, and where ``$TERM`` is set to one of ``cygwin,xterm*,putty*,rxvt*,ansi,screen*,tmux*``

--- a/README.md
+++ b/README.md
@@ -124,6 +124,30 @@ This must be declared **before** loading the plugin in your `.zshrc`. The mappin
 
 **Example**: When running `node server.js`, the tab title will show `NodeJS` (or `NodeJS server.js` if `ZSH_TAB_TITLE_ENABLE_FULL_COMMAND=true`).
 
+### CUSTOM TAB TITLE OVERRIDE
+
+You can force a specific tab title for individual commands by setting the `ZSH_TAB_PROMPT` environment variable. This bypasses all automatic command parsing, mapping, and concatenation logic.
+
+**Syntax:**
+
+```sh
+env ZSH_TAB_PROMPT="Custom Title" command
+ZSH_TAB_PROMPT="Custom Title" command
+```
+
+**Examples:**
+
+```sh
+# Running Claude Code with a custom tab title
+env ZSH_TAB_PROMPT="Claude Code" claude
+
+# Running a development server with project name
+ZSH_TAB_PROMPT="API Dev" npm run dev
+
+# Multiple environment variables with custom title
+DEBUG=true ZSH_TAB_PROMPT="Debug Mode" node server.js
+```
+
 ### ADDITIONAL TERMS
 
 By default the tab title is set for iTerm, Hyper, and where ``$TERM`` is set to one of ``cygwin,xterm*,putty*,rxvt*,ansi,screen*,tmux*``

--- a/zsh-tab-title.plugin.zsh
+++ b/zsh-tab-title.plugin.zsh
@@ -14,6 +14,9 @@ _in_zellij() { [[ -n "$ZELLIJ" || -n "$ZELLIJ_SESSION_NAME" ]]; }
 _zt_rename_tab()  { command zellij action rename-tab  "$1" >/dev/null 2>&1; }
 _zt_rename_pane() { command zellij action rename-pane "$1" >/dev/null 2>&1; }
 
+# Optional associative arrays for custom name mapping
+(( ${+ZSH_TAB_TITLE_CMD_MAP} )) || typeset -gA ZSH_TAB_TITLE_CMD_MAP
+
 function title {
   emulate -L zsh
   setopt prompt_subst
@@ -105,6 +108,22 @@ function omz_termsupport_preexec {
 	  # cmd name only, or if this is sudo or ssh, the next cmd
 	  local CMD=${1[(wr)^(*=*|sudo|ssh|mosh|rake|-*)]:gs/%/%%}
     local LINE=${2[(wr)^(*=*|sudo|ssh|mosh|rake|-*)]:gs/%/%%}
+  fi
+
+  if (( ${+ZSH_TAB_TITLE_CMD_MAP} )) && (( ${#ZSH_TAB_TITLE_CMD_MAP} > 0 )); then
+    local base_cmd="${CMD}"
+
+    if [[ -n "${ZSH_TAB_TITLE_CMD_MAP[$base_cmd]:-}" ]]; then
+      local mapped_cmd="${ZSH_TAB_TITLE_CMD_MAP[$base_cmd]}"
+
+      CMD="$mapped_cmd"
+
+      if [[ "$ZSH_TAB_TITLE_ENABLE_FULL_COMMAND" == true ]]; then
+        LINE="${LINE/$base_cmd/$mapped_cmd}"
+      else
+        LINE="$mapped_cmd"
+      fi
+    fi
   fi
 
   if [[ "$ZSH_TAB_TITLE_CONCAT_FOLDER_PROCESS" == true ]]; then

--- a/zsh-tab-title.plugin.zsh
+++ b/zsh-tab-title.plugin.zsh
@@ -100,6 +100,30 @@ function omz_termsupport_preexec {
     return
   fi
 
+  # Check for ZSH_TAB_PROMPT environment variable override
+  local zsh_tab_prompt_override=""
+  local args
+  args=("${(z)1}")  # Tokenize command line, respecting quotes
+
+  # Search for ZSH_TAB_PROMPT= assignment
+  for arg in "${args[@]}"; do
+    if [[ "$arg" == ZSH_TAB_PROMPT=* ]]; then
+      zsh_tab_prompt_override="${arg#ZSH_TAB_PROMPT=}"
+      # Remove surrounding quotes if present
+      zsh_tab_prompt_override="${zsh_tab_prompt_override%\"}"
+      zsh_tab_prompt_override="${zsh_tab_prompt_override#\"}"
+      zsh_tab_prompt_override="${zsh_tab_prompt_override%\'}"
+      zsh_tab_prompt_override="${zsh_tab_prompt_override#\'}"
+      break
+    fi
+  done
+
+  # If override found and non-empty, use it and skip normal parsing
+  if [[ -n "$zsh_tab_prompt_override" ]]; then
+    title "$zsh_tab_prompt_override" "$zsh_tab_prompt_override"
+    return
+  fi
+
   if [[ "$ZSH_TAB_TITLE_ENABLE_FULL_COMMAND" == true ]]; then
   	  # full command
 	  local CMD=${1:gs/%/%%}


### PR DESCRIPTION
This pull request adds two features to the zsh-tab-title plugin: support for mapping command names to custom display names using an associative array, and the ability to override the tab title for individual commands via an environment variable. 

**New features for customizing tab titles:**

* Added support for mapping command names to custom display names via the `ZSH_TAB_TITLE_CMD_MAP` associative array, allowing users to display friendly or icon-enhanced names for frequently used commands. (`README.md`, `zsh-tab-title.plugin.zsh`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R108-R150) [[2]](diffhunk://#diff-713feae969de3b0f2defca1398fb9fb9f8103c1cf177a4c35599ca53c24197ceR17-R19) [[3]](diffhunk://#diff-713feae969de3b0f2defca1398fb9fb9f8103c1cf177a4c35599ca53c24197ceR137-R152)
* Introduced the `ZSH_TAB_PROMPT` environment variable, which allows users to override the tab title for a specific command, bypassing all automatic parsing and mapping logic. (`README.md`, `zsh-tab-title.plugin.zsh`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R108-R150) [[2]](diffhunk://#diff-713feae969de3b0f2defca1398fb9fb9f8103c1cf177a4c35599ca53c24197ceR103-R126)

