### PR TITLE
feat: customize cwd truncation in idle tab title

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,14 @@ You can display in the tab title, just the last folder you are in. So for exampl
 ZSH_TAB_TITLE_ONLY_FOLDER=true
 ```
 
+### TRUNCATE WORKING DIRECTORY IN IDLE TITLE
+
+Change the amount of characters to which the current working directory should be truncated in the idle tab title if `ZSH_TAB_TITLE_ONLY_FOLDER=false.`
+
+```sh
+ZSH_TAB_TITLE_IDLE_CWD_TRUNCATE_LENGTH=20
+```
+
 ### CONCAT FOLDER AND PROCESS
 
 When executing a command, it is showed in the tab title. You can setup to concatenate the current folder to it, so it can display, for example, `zsh-tab-title:ls`, when doing a `ls` in `/home/user/zsh-tab-title`. To enable concat folder and process, do:

--- a/zsh-tab-title.plugin.zsh
+++ b/zsh-tab-title.plugin.zsh
@@ -67,7 +67,8 @@ function setTerminalTitleInIdle {
   if [[ "${ZSH_TAB_TITLE_ONLY_FOLDER:-}" == true ]]; then
     ZSH_THEME_TERM_TAB_TITLE_IDLE=${PWD##*/}
   else
-    ZSH_THEME_TERM_TAB_TITLE_IDLE="%20<..<%~%<<" #15 char left truncated PWD
+    # default 20 char left truncated CWD
+    ZSH_THEME_TERM_TAB_TITLE_IDLE="%${ZSH_TAB_TITLE_IDLE_CWD_TRUNCATE_LENGTH:-20}<..<%~%<<" 
   fi
 
   if [[ "${ZSH_TAB_TITLE_DEFAULT_DISABLE_PREFIX:-}" == true ]]; then


### PR DESCRIPTION
New feature allows users to set a custom amount of characters to which
the current working directory will be truncated in the idle tab title.
